### PR TITLE
fix: retry semantic release

### DIFF
--- a/packages/zipkin-transport-kafka/test/unitTest.js
+++ b/packages/zipkin-transport-kafka/test/unitTest.js
@@ -71,7 +71,6 @@ describe('Kafka transport - unit tests', () => {
     });
   });
 
-
   it('Should throw errors gracefully when Kafka-Node fails to connect', function(done) {
     this.timeout(60 * 1000);
 


### PR DESCRIPTION
didn't work for a README change